### PR TITLE
add grafana and portrainer

### DIFF
--- a/tools.yml
+++ b/tools.yml
@@ -1,0 +1,104 @@
+version: '3.11'
+
+networks:
+  monitor:
+    driver: overlay
+    name: monitor
+    external: true
+  agent_network:
+    driver: overlay
+  
+volumes:
+  portainer_data:
+  grafana_data:
+
+services:
+  portainer:
+    image: portainer/portainer-ce:lts
+    command: -H tcp://tasks.agent:9001 --tlsskipverify
+    ports:
+      - "9443:9443"
+      - "9000:9000"
+      - "8000:8000"
+    volumes:
+      - portainer_data:/data
+    networks:
+      - monitor
+      - agent_network
+    deploy:
+      mode: replicated
+      replicas: 1
+      resources:
+        limits:
+          cpus: '1'
+          memory: 500M
+        reservations:
+          cpus: '0.25'
+          memory: 100M
+      placement:
+        constraints: [node.role == manager]
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.portainer.rule=Host(`cluster.localhost`)"
+        - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+        - "traefik.http.routers.portainer.entrypoints=websecure"
+        - "traefik.http.routers.portainer.tls=true"
+        - "traefik.swarm.network=monitor"
+      restart_policy:
+        condition: on-failure
+  agent:
+    image: portainer/agent:lts
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes
+    networks:
+      - agent_network
+    deploy:
+      mode: global
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 100M
+        reservations:
+          cpus: '0.25'
+          memory: 50M
+      placement:
+        constraints: [node.platform.os == linux]
+      labels:
+        - "traefik.enable=false"
+      restart_policy:
+        condition: on-failure
+
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+      - traefik
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    env_file:
+      - ./grafana/config.monitoring
+    networks:
+      - monitor
+    user: "472"
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 500M
+        reservations:
+          cpus: '0.25'
+          memory: 100M
+      placement:
+        constraints:
+          - node.role==manager
+      labels:
+        - "traefik.enable=true"
+        - "traefik.http.routers.grafana.rule=Host(`monitor.localhost`)"
+        - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+        - "traefik.http.routers.grafana.entrypoints=websecure"
+        - "traefik.http.routers.grafana.tls=true"
+        - "traefik.swarm.network=monitor"
+      restart_policy:
+        condition: on-failure


### PR DESCRIPTION

```sh
╭─ ~/development/docker/selfhosted-swarm
╰─$ docker stack deploy --detach -c tools.yml tools 
Creating network tools_agent_network
Creating service tools_agent
Creating service tools_grafana
Creating service tools_portainer
╭─ ~/development/docker/selfhosted-swarm
╰─$ docker service ls 
ID             NAME                      MODE         REPLICAS   IMAGE                                     PORTS
cgi02mie0iop   monitor_cadvisor          global       2/2        gcr.io/cadvisor/cadvisor:latest           *:8080->8080/tcp
m71i3u5y6vjl   monitor_nodeexporter      global       2/2        quay.io/prometheus/node-exporter:latest   *:9100->9100/tcp
nsiru0x76v96   monitor_processexporter   global       2/2        ncabatoff/process-exporter:latest         
sebrszh09ah8   monitor_prometheus        replicated   1/1        prom/prometheus:v2.36.2                   *:9090->9090/tcp
cq6ny4zu5bwl   proxy_traefik             global       2/2        traefik:v3.3                              *:8088->8080/tcp
xxjpk68bgxw0   tools_agent               global       2/2        portainer/agent:lts                       
ye30mhglcf8m   tools_grafana             replicated   1/1        grafana/grafana:latest                    
6ifhl6o2jzs6   tools_portainer           replicated   1/1        portainer/portainer-ce:lts                *:8000->8000/tcp, *:9000->9000/tcp, *:9443->9443/tcp
```